### PR TITLE
Add theme, autocomplete and autosuggestions for zsh

### DIFF
--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -3,6 +3,7 @@ DOTFILES_BASE=$HOME/dotfiles
 source $HOME/.zsh/antigen/antigen.zsh
 
 antigen use oh-my-zsh
+antigen theme simple
 
 ## Load macOS specific bundles
 if [[ $OSTYPE == darwin* ]]; then
@@ -11,8 +12,10 @@ fi
 
 ## Batch load bundles
 antigen bundles <<EOBUNDLES
-  git
+  zsh-users/zsh-completions
   zsh-users/zsh-syntax-highlighting
+  zsh-users/zsh-autosuggestions
+  git
 EOBUNDLES
 
 ## Must be run after loading the bundles to finalise


### PR DESCRIPTION
This PR configures `zsh` using `antigen` to use `autocomplete`, `autosuggestions` and the `zsh` simple theme.